### PR TITLE
Fix Tests & Add NullableReferenceType-Annotations

### DIFF
--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -37,7 +37,10 @@ string GetContent(bool isStruct, int i) {
     var genericArg = genericArgs.Joined(", ");
     var sb = new StringBuilder();
     
-    sb.Append(@$"using System;
+    sb.Append(@$"#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
@@ -45,11 +48,11 @@ namespace OneOf
     public {IfStruct("readonly struct", "class")} {className}<{genericArg}> : IOneOf
     {{
         {RangeJoined(@"
-        ", j => $"readonly T{j} _value{j};")}
+        ", j => $"readonly T{j}? _value{j};")}
         readonly int _index;
 
         {IfStruct( // constructor
-        $@"OneOf(int index, {RangeJoined(", ", j => $"T{j} value{j} = default")})
+        $@"OneOf(int index, {RangeJoined(", ", j => $"T{j}? value{j} = default")})
         {{
             _index = index;
             {RangeJoined(@"
@@ -67,7 +70,7 @@ namespace OneOf
         }}"
         )}
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {{
                 {RangeJoined(@"
@@ -83,29 +86,29 @@ namespace OneOf
         {RangeJoined(@"
         ", j => $@"public T{j} AsT{j} =>
             _index == {j} ?
-                _value{j} :
+                _value{j}! :
                 throw new InvalidOperationException($""Cannot return as T{j} as result is T{{_index}}"");")}
 
         {IfStruct(RangeJoined(@"
         ", j => $"public static implicit operator {className}<{genericArg}>(T{j} t) => new {className}<{genericArg}>({j}, value{j}: t);"))}
 
-        public void Switch({RangeJoined(", ", e => $"Action<T{e}> f{e}")})
+        public void Switch({RangeJoined(", ", e => $"Action<T{e}>? f{e}")})
         {{
             {RangeJoined(@"
             ", j => @$"if (_index == {j} && f{j} != null)
             {{
-                f{j}(_value{j});
+                f{j}(_value{j}!);
                 return;
             }}")}
             throw new InvalidOperationException();
         }}
 
-        public TResult Match<TResult>({RangeJoined(", ", e => $"Func<T{e}, TResult> f{e}")})
+        public TResult Match<TResult>({RangeJoined(", ", e => $"Func<T{e}, TResult>? f{e}")})
         {{
             {RangeJoined(@"
             ", j => $@"if (_index == {j} && f{j} != null)
             {{
-                return f{j}(_value{j});
+                return f{j}(_value{j}!);
             }}")}
             throw new InvalidOperationException();
         }}
@@ -130,8 +133,8 @@ namespace OneOf
                 {genericArgs.Joined(@"
                 ", (x, k) =>
                     x == bindToType ?
-                        $"{k} => mapFunc(As{x})," :
-                        $"{k} => As{x},")}
+                        $"{k} => mapFunc(_value{k}!)," :
+                        $"{k} => _value{k}!,")}
                 _ => throw new InvalidOperationException()
             }};
         }}";
@@ -145,7 +148,7 @@ namespace OneOf
                 var genericArgWithSkip = Range(0, i).ExceptSingle(j).Joined(", ", e => $"T{e}");
                 var remainderType = i == 2 ? genericArgWithSkip : $"OneOf<{genericArgWithSkip}>";
                 return $@"
-		public bool TryPickT{j}(out T{j} value, out {remainderType} remainder)
+		public bool TryPickT{j}([MaybeNullWhen(false)] out T{j} value, [MaybeNullWhen(true)] out {remainderType} remainder)
 		{{
 			value = IsT{j} ? AsT{j} : default;
             remainder = _index switch
@@ -154,7 +157,7 @@ namespace OneOf
                 ", k => 
                     k == j ?
                         $"{k} => default," :
-                        $"{k} => AsT{k},")}
+                        $"{k} => _value{k}!,")}
                 _ => throw new InvalidOperationException()
             }};
 			return this.IsT{j};
@@ -173,7 +176,7 @@ namespace OneOf
                 _ => false
             }};
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {{
             if (ReferenceEquals(null, obj))
             {{

--- a/OneOf.Extended/AttributePolyfill.cs
+++ b/OneOf.Extended/AttributePolyfill.cs
@@ -1,0 +1,19 @@
+﻿#if !NETSTANDARD2_1 && !NETSTANDARD2_1_OR_GREATER && !NETCOREAPP2_1_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis {
+    /// <summary>Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.ReturnValue" />, the parameter may be <see langword="null" /> even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">The return value condition. If the method returns this value, the associated parameter may be <see langword="null" />.</param>
+        public MaybeNullWhenAttribute(bool returnValue) {
+            ReturnValue = returnValue;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        /// <returns>The return value condition. If the method returns this value, the associated parameter may be <see langword="null" />.</returns>
+        public bool ReturnValue { get; }
+    }
+}
+
+#endif

--- a/OneOf.Extended/OneOf.Extended.csproj
+++ b/OneOf.Extended/OneOf.Extended.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35;net45;netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Authors>Harry McIntyre</Authors>
     <Title>OneOf - Easy Discriminated Unions for c#</Title>
     <Company>Harry McIntyre</Company>
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 

--- a/OneOf.Extended/OneOfBaseT10.generated.cs
+++ b/OneOf.Extended/OneOfBaseT10.generated.cs
@@ -1,21 +1,24 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> input)
@@ -38,7 +41,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -71,156 +74,156 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             throw new InvalidOperationException();
         }
@@ -229,231 +232,231 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -478,7 +481,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT11.generated.cs
+++ b/OneOf.Extended/OneOfBaseT11.generated.cs
@@ -1,22 +1,25 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> input)
@@ -40,7 +43,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -75,169 +78,169 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             throw new InvalidOperationException();
         }
@@ -246,264 +249,264 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -529,7 +532,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT12.generated.cs
+++ b/OneOf.Extended/OneOfBaseT12.generated.cs
@@ -1,23 +1,26 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> input)
@@ -42,7 +45,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -79,182 +82,182 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             throw new InvalidOperationException();
         }
@@ -263,299 +266,299 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -582,7 +585,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT13.generated.cs
+++ b/OneOf.Extended/OneOfBaseT13.generated.cs
@@ -1,24 +1,27 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> input)
@@ -44,7 +47,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -83,195 +86,195 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             throw new InvalidOperationException();
         }
@@ -280,336 +283,336 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -637,7 +640,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT14.generated.cs
+++ b/OneOf.Extended/OneOfBaseT14.generated.cs
@@ -1,25 +1,28 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> input)
@@ -46,7 +49,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -87,208 +90,208 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             throw new InvalidOperationException();
         }
@@ -297,375 +300,375 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -694,7 +697,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT15.generated.cs
+++ b/OneOf.Extended/OneOfBaseT15.generated.cs
@@ -1,26 +1,29 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> input)
@@ -48,7 +51,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -91,221 +94,221 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             throw new InvalidOperationException();
         }
@@ -314,416 +317,416 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -753,7 +756,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT16.generated.cs
+++ b/OneOf.Extended/OneOfBaseT16.generated.cs
@@ -1,27 +1,30 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> input)
@@ -50,7 +53,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -95,234 +98,234 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             throw new InvalidOperationException();
         }
@@ -331,459 +334,459 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -814,7 +817,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT17.generated.cs
+++ b/OneOf.Extended/OneOfBaseT17.generated.cs
@@ -1,28 +1,31 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> input)
@@ -52,7 +55,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -99,247 +102,247 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             throw new InvalidOperationException();
         }
@@ -348,504 +351,504 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -877,7 +880,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT18.generated.cs
+++ b/OneOf.Extended/OneOfBaseT18.generated.cs
@@ -1,29 +1,32 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> input)
@@ -54,7 +57,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -103,260 +106,260 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             throw new InvalidOperationException();
         }
@@ -365,551 +368,551 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -942,7 +945,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT19.generated.cs
+++ b/OneOf.Extended/OneOfBaseT19.generated.cs
@@ -1,30 +1,33 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> input)
@@ -56,7 +59,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -107,273 +110,273 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             throw new InvalidOperationException();
         }
@@ -382,600 +385,600 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1009,7 +1012,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT20.generated.cs
+++ b/OneOf.Extended/OneOfBaseT20.generated.cs
@@ -1,31 +1,34 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> input)
@@ -58,7 +61,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -111,286 +114,286 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             throw new InvalidOperationException();
         }
@@ -399,651 +402,651 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1078,7 +1081,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT21.generated.cs
+++ b/OneOf.Extended/OneOfBaseT21.generated.cs
@@ -1,32 +1,35 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> input)
@@ -60,7 +63,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -115,299 +118,299 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             throw new InvalidOperationException();
         }
@@ -416,704 +419,704 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1149,7 +1152,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT22.generated.cs
+++ b/OneOf.Extended/OneOfBaseT22.generated.cs
@@ -1,33 +1,36 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> input)
@@ -62,7 +65,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -119,312 +122,312 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             throw new InvalidOperationException();
         }
@@ -433,759 +436,759 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1222,7 +1225,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT23.generated.cs
+++ b/OneOf.Extended/OneOfBaseT23.generated.cs
@@ -1,34 +1,37 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> input)
@@ -64,7 +67,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -123,325 +126,325 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             throw new InvalidOperationException();
         }
@@ -450,816 +453,816 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1297,7 +1300,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT24.generated.cs
+++ b/OneOf.Extended/OneOfBaseT24.generated.cs
@@ -1,35 +1,38 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> input)
@@ -66,7 +69,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -127,338 +130,338 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             throw new InvalidOperationException();
         }
@@ -467,875 +470,875 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1374,7 +1377,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT25.generated.cs
+++ b/OneOf.Extended/OneOfBaseT25.generated.cs
@@ -1,36 +1,39 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> input)
@@ -68,7 +71,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -131,351 +134,351 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             throw new InvalidOperationException();
         }
@@ -484,936 +487,936 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1453,7 +1456,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT26.generated.cs
+++ b/OneOf.Extended/OneOfBaseT26.generated.cs
@@ -1,37 +1,40 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> input)
@@ -70,7 +73,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -135,364 +138,364 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             throw new InvalidOperationException();
         }
@@ -501,999 +504,999 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1534,7 +1537,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT27.generated.cs
+++ b/OneOf.Extended/OneOfBaseT27.generated.cs
@@ -1,38 +1,41 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
-        readonly T27 _value27;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
+        readonly T27? _value27;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> input)
@@ -72,7 +75,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -139,377 +142,377 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
         public T27 AsT27 =>
             _index == 27 ?
-                _value27 :
+                _value27! :
                 throw new InvalidOperationException($"Cannot return as T27 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26, Action<T27>? f27)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             if (_index == 27 && f27 != null)
             {
-                f27(_value27);
+                f27(_value27!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26, Func<T27, TResult>? f27)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             if (_index == 27 && f27 != null)
             {
-                return f27(_value27);
+                return f27(_value27!);
             }
             throw new InvalidOperationException();
         }
@@ -518,1064 +521,1064 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
-                27 => AsT27,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
-                27 => AsT27,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT26;
 		}
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT27([MaybeNullWhen(false)] out T27 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT27 ? AsT27 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 27 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1617,7 +1620,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT28.generated.cs
+++ b/OneOf.Extended/OneOfBaseT28.generated.cs
@@ -1,39 +1,42 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
-        readonly T27 _value27;
-        readonly T28 _value28;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
+        readonly T27? _value27;
+        readonly T28? _value28;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> input)
@@ -74,7 +77,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -143,390 +146,390 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
         public T27 AsT27 =>
             _index == 27 ?
-                _value27 :
+                _value27! :
                 throw new InvalidOperationException($"Cannot return as T27 as result is T{_index}");
         public T28 AsT28 =>
             _index == 28 ?
-                _value28 :
+                _value28! :
                 throw new InvalidOperationException($"Cannot return as T28 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26, Action<T27>? f27, Action<T28>? f28)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             if (_index == 27 && f27 != null)
             {
-                f27(_value27);
+                f27(_value27!);
                 return;
             }
             if (_index == 28 && f28 != null)
             {
-                f28(_value28);
+                f28(_value28!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26, Func<T27, TResult>? f27, Func<T28, TResult>? f28)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             if (_index == 27 && f27 != null)
             {
-                return f27(_value27);
+                return f27(_value27!);
             }
             if (_index == 28 && f28 != null)
             {
-                return f28(_value28);
+                return f28(_value28!);
             }
             throw new InvalidOperationException();
         }
@@ -535,1131 +538,1131 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
-                27 => AsT27,
-                28 => AsT28,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT26;
 		}
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28> remainder)
+		public bool TryPickT27([MaybeNullWhen(false)] out T27 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28> remainder)
 		{
 			value = IsT27 ? AsT27 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 27 => default,
-                28 => AsT28,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT27;
 		}
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT28([MaybeNullWhen(false)] out T28 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT28 ? AsT28 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 28 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1702,7 +1705,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT29.generated.cs
+++ b/OneOf.Extended/OneOfBaseT29.generated.cs
@@ -1,40 +1,43 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
-        readonly T27 _value27;
-        readonly T28 _value28;
-        readonly T29 _value29;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
+        readonly T27? _value27;
+        readonly T28? _value28;
+        readonly T29? _value29;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> input)
@@ -76,7 +79,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -147,403 +150,403 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
         public T27 AsT27 =>
             _index == 27 ?
-                _value27 :
+                _value27! :
                 throw new InvalidOperationException($"Cannot return as T27 as result is T{_index}");
         public T28 AsT28 =>
             _index == 28 ?
-                _value28 :
+                _value28! :
                 throw new InvalidOperationException($"Cannot return as T28 as result is T{_index}");
         public T29 AsT29 =>
             _index == 29 ?
-                _value29 :
+                _value29! :
                 throw new InvalidOperationException($"Cannot return as T29 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26, Action<T27>? f27, Action<T28>? f28, Action<T29>? f29)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             if (_index == 27 && f27 != null)
             {
-                f27(_value27);
+                f27(_value27!);
                 return;
             }
             if (_index == 28 && f28 != null)
             {
-                f28(_value28);
+                f28(_value28!);
                 return;
             }
             if (_index == 29 && f29 != null)
             {
-                f29(_value29);
+                f29(_value29!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26, Func<T27, TResult>? f27, Func<T28, TResult>? f28, Func<T29, TResult>? f29)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             if (_index == 27 && f27 != null)
             {
-                return f27(_value27);
+                return f27(_value27!);
             }
             if (_index == 28 && f28 != null)
             {
-                return f28(_value28);
+                return f28(_value28!);
             }
             if (_index == 29 && f29 != null)
             {
-                return f29(_value29);
+                return f29(_value29!);
             }
             throw new InvalidOperationException();
         }
@@ -552,1200 +555,1200 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT26;
 		}
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29> remainder)
+		public bool TryPickT27([MaybeNullWhen(false)] out T27 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29> remainder)
 		{
 			value = IsT27 ? AsT27 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 27 => default,
-                28 => AsT28,
-                29 => AsT29,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT27;
 		}
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29> remainder)
+		public bool TryPickT28([MaybeNullWhen(false)] out T28 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29> remainder)
 		{
 			value = IsT28 ? AsT28 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 28 => default,
-                29 => AsT29,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT28;
 		}
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT29([MaybeNullWhen(false)] out T29 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT29 ? AsT29 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 29 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1789,7 +1792,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT30.generated.cs
+++ b/OneOf.Extended/OneOfBaseT30.generated.cs
@@ -1,41 +1,44 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
-        readonly T27 _value27;
-        readonly T28 _value28;
-        readonly T29 _value29;
-        readonly T30 _value30;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
+        readonly T27? _value27;
+        readonly T28? _value28;
+        readonly T29? _value29;
+        readonly T30? _value30;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> input)
@@ -78,7 +81,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -151,416 +154,416 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
         public T27 AsT27 =>
             _index == 27 ?
-                _value27 :
+                _value27! :
                 throw new InvalidOperationException($"Cannot return as T27 as result is T{_index}");
         public T28 AsT28 =>
             _index == 28 ?
-                _value28 :
+                _value28! :
                 throw new InvalidOperationException($"Cannot return as T28 as result is T{_index}");
         public T29 AsT29 =>
             _index == 29 ?
-                _value29 :
+                _value29! :
                 throw new InvalidOperationException($"Cannot return as T29 as result is T{_index}");
         public T30 AsT30 =>
             _index == 30 ?
-                _value30 :
+                _value30! :
                 throw new InvalidOperationException($"Cannot return as T30 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29, Action<T30> f30)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26, Action<T27>? f27, Action<T28>? f28, Action<T29>? f29, Action<T30>? f30)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             if (_index == 27 && f27 != null)
             {
-                f27(_value27);
+                f27(_value27!);
                 return;
             }
             if (_index == 28 && f28 != null)
             {
-                f28(_value28);
+                f28(_value28!);
                 return;
             }
             if (_index == 29 && f29 != null)
             {
-                f29(_value29);
+                f29(_value29!);
                 return;
             }
             if (_index == 30 && f30 != null)
             {
-                f30(_value30);
+                f30(_value30!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29, Func<T30, TResult> f30)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26, Func<T27, TResult>? f27, Func<T28, TResult>? f28, Func<T29, TResult>? f29, Func<T30, TResult>? f30)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             if (_index == 27 && f27 != null)
             {
-                return f27(_value27);
+                return f27(_value27!);
             }
             if (_index == 28 && f28 != null)
             {
-                return f28(_value28);
+                return f28(_value28!);
             }
             if (_index == 29 && f29 != null)
             {
-                return f29(_value29);
+                return f29(_value29!);
             }
             if (_index == 30 && f30 != null)
             {
-                return f30(_value30);
+                return f30(_value30!);
             }
             throw new InvalidOperationException();
         }
@@ -569,1271 +572,1271 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT26;
 		}
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30> remainder)
+		public bool TryPickT27([MaybeNullWhen(false)] out T27 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30> remainder)
 		{
 			value = IsT27 ? AsT27 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 27 => default,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT27;
 		}
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30> remainder)
+		public bool TryPickT28([MaybeNullWhen(false)] out T28 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30> remainder)
 		{
 			value = IsT28 ? AsT28 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 28 => default,
-                29 => AsT29,
-                30 => AsT30,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT28;
 		}
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30> remainder)
+		public bool TryPickT29([MaybeNullWhen(false)] out T29 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30> remainder)
 		{
 			value = IsT29 ? AsT29 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 29 => default,
-                30 => AsT30,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT29;
 		}
         
-		public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT30([MaybeNullWhen(false)] out T30 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT30 ? AsT30 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 30 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1878,7 +1881,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT31.generated.cs
+++ b/OneOf.Extended/OneOfBaseT31.generated.cs
@@ -1,42 +1,45 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
-        readonly T27 _value27;
-        readonly T28 _value28;
-        readonly T29 _value29;
-        readonly T30 _value30;
-        readonly T31 _value31;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
+        readonly T27? _value27;
+        readonly T28? _value28;
+        readonly T29? _value29;
+        readonly T30? _value30;
+        readonly T31? _value31;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> input)
@@ -80,7 +83,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -155,429 +158,429 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
         public T27 AsT27 =>
             _index == 27 ?
-                _value27 :
+                _value27! :
                 throw new InvalidOperationException($"Cannot return as T27 as result is T{_index}");
         public T28 AsT28 =>
             _index == 28 ?
-                _value28 :
+                _value28! :
                 throw new InvalidOperationException($"Cannot return as T28 as result is T{_index}");
         public T29 AsT29 =>
             _index == 29 ?
-                _value29 :
+                _value29! :
                 throw new InvalidOperationException($"Cannot return as T29 as result is T{_index}");
         public T30 AsT30 =>
             _index == 30 ?
-                _value30 :
+                _value30! :
                 throw new InvalidOperationException($"Cannot return as T30 as result is T{_index}");
         public T31 AsT31 =>
             _index == 31 ?
-                _value31 :
+                _value31! :
                 throw new InvalidOperationException($"Cannot return as T31 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29, Action<T30> f30, Action<T31> f31)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26, Action<T27>? f27, Action<T28>? f28, Action<T29>? f29, Action<T30>? f30, Action<T31>? f31)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             if (_index == 27 && f27 != null)
             {
-                f27(_value27);
+                f27(_value27!);
                 return;
             }
             if (_index == 28 && f28 != null)
             {
-                f28(_value28);
+                f28(_value28!);
                 return;
             }
             if (_index == 29 && f29 != null)
             {
-                f29(_value29);
+                f29(_value29!);
                 return;
             }
             if (_index == 30 && f30 != null)
             {
-                f30(_value30);
+                f30(_value30!);
                 return;
             }
             if (_index == 31 && f31 != null)
             {
-                f31(_value31);
+                f31(_value31!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29, Func<T30, TResult> f30, Func<T31, TResult> f31)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26, Func<T27, TResult>? f27, Func<T28, TResult>? f28, Func<T29, TResult>? f29, Func<T30, TResult>? f30, Func<T31, TResult>? f31)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             if (_index == 27 && f27 != null)
             {
-                return f27(_value27);
+                return f27(_value27!);
             }
             if (_index == 28 && f28 != null)
             {
-                return f28(_value28);
+                return f28(_value28!);
             }
             if (_index == 29 && f29 != null)
             {
-                return f29(_value29);
+                return f29(_value29!);
             }
             if (_index == 30 && f30 != null)
             {
-                return f30(_value30);
+                return f30(_value30!);
             }
             if (_index == 31 && f31 != null)
             {
-                return f31(_value31);
+                return f31(_value31!);
             }
             throw new InvalidOperationException();
         }
@@ -586,1344 +589,1344 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT26;
 		}
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30, T31> remainder)
+		public bool TryPickT27([MaybeNullWhen(false)] out T27 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30, T31> remainder)
 		{
 			value = IsT27 ? AsT27 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 27 => default,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT27;
 		}
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30, T31> remainder)
+		public bool TryPickT28([MaybeNullWhen(false)] out T28 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30, T31> remainder)
 		{
 			value = IsT28 ? AsT28 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 28 => default,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT28;
 		}
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30, T31> remainder)
+		public bool TryPickT29([MaybeNullWhen(false)] out T29 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30, T31> remainder)
 		{
 			value = IsT29 ? AsT29 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 29 => default,
-                30 => AsT30,
-                31 => AsT31,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT29;
 		}
         
-		public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T31> remainder)
+		public bool TryPickT30([MaybeNullWhen(false)] out T30 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T31> remainder)
 		{
 			value = IsT30 ? AsT30 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 30 => default,
-                31 => AsT31,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT30;
 		}
         
-		public bool TryPickT31(out T31 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT31([MaybeNullWhen(false)] out T31 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT31 ? AsT31 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 31 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1969,7 +1972,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfBaseT9.generated.cs
+++ b/OneOf.Extended/OneOfBaseT9.generated.cs
@@ -1,20 +1,23 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> input)
@@ -36,7 +39,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -67,143 +70,143 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             throw new InvalidOperationException();
         }
@@ -212,200 +215,200 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -429,7 +432,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT10.generated.cs
+++ b/OneOf.Extended/OneOfT10.generated.cs
@@ -1,24 +1,27 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default)
         {
             _index = index;
             _value0 = value0;
@@ -34,7 +37,7 @@ namespace OneOf
             _value10 = value10;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -67,47 +70,47 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(0, value0: t);
@@ -122,111 +125,111 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(9, value9: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(10, value10: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             throw new InvalidOperationException();
         }
@@ -252,17 +255,17 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -275,17 +278,17 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -298,17 +301,17 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -321,17 +324,17 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -344,17 +347,17 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -367,17 +370,17 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -390,17 +393,17 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -413,17 +416,17 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -436,17 +439,17 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -459,17 +462,17 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -482,246 +485,246 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
+                9 => _value9!,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
+                10 => _value10!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -746,7 +749,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT11.generated.cs
+++ b/OneOf.Extended/OneOfT11.generated.cs
@@ -1,25 +1,28 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default)
         {
             _index = index;
             _value0 = value0;
@@ -36,7 +39,7 @@ namespace OneOf
             _value11 = value11;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -71,51 +74,51 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(0, value0: t);
@@ -131,120 +134,120 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(10, value10: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(11, value11: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             throw new InvalidOperationException();
         }
@@ -271,18 +274,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -295,18 +298,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -319,18 +322,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -343,18 +346,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -367,18 +370,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -391,18 +394,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -415,18 +418,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -439,18 +442,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -463,18 +466,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -487,18 +490,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -511,18 +514,18 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -535,280 +538,280 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
+                10 => _value10!,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
+                11 => _value11!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -834,7 +837,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT12.generated.cs
+++ b/OneOf.Extended/OneOfT12.generated.cs
@@ -1,26 +1,29 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default)
         {
             _index = index;
             _value0 = value0;
@@ -38,7 +41,7 @@ namespace OneOf
             _value12 = value12;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -75,55 +78,55 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(0, value0: t);
@@ -140,129 +143,129 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(11, value11: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(12, value12: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             throw new InvalidOperationException();
         }
@@ -290,19 +293,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -315,19 +318,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -340,19 +343,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -365,19 +368,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -390,19 +393,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -415,19 +418,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -440,19 +443,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -465,19 +468,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -490,19 +493,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -515,19 +518,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -540,19 +543,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -565,19 +568,19 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -590,316 +593,316 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
+                11 => _value11!,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
+                12 => _value12!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -926,7 +929,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT13.generated.cs
+++ b/OneOf.Extended/OneOfT13.generated.cs
@@ -1,27 +1,30 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default)
         {
             _index = index;
             _value0 = value0;
@@ -40,7 +43,7 @@ namespace OneOf
             _value13 = value13;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -79,59 +82,59 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(0, value0: t);
@@ -149,138 +152,138 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(12, value12: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(13, value13: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             throw new InvalidOperationException();
         }
@@ -309,20 +312,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -335,20 +338,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -361,20 +364,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -387,20 +390,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -413,20 +416,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -439,20 +442,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -465,20 +468,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -491,20 +494,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -517,20 +520,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -543,20 +546,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -569,20 +572,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -595,20 +598,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -621,20 +624,20 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -647,354 +650,354 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
+                12 => _value12!,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
+                13 => _value13!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1022,7 +1025,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT14.generated.cs
+++ b/OneOf.Extended/OneOfT14.generated.cs
@@ -1,28 +1,31 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default)
         {
             _index = index;
             _value0 = value0;
@@ -42,7 +45,7 @@ namespace OneOf
             _value14 = value14;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -83,63 +86,63 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(0, value0: t);
@@ -158,147 +161,147 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(13, value13: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(14, value14: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             throw new InvalidOperationException();
         }
@@ -328,21 +331,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -355,21 +358,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -382,21 +385,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -409,21 +412,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -436,21 +439,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -463,21 +466,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -490,21 +493,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -517,21 +520,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -544,21 +547,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -571,21 +574,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -598,21 +601,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -625,21 +628,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -652,21 +655,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -679,21 +682,21 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -706,394 +709,394 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
+                13 => _value13!,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
+                14 => _value14!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1122,7 +1125,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT15.generated.cs
+++ b/OneOf.Extended/OneOfT15.generated.cs
@@ -1,29 +1,32 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default)
         {
             _index = index;
             _value0 = value0;
@@ -44,7 +47,7 @@ namespace OneOf
             _value15 = value15;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -87,67 +90,67 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(0, value0: t);
@@ -167,156 +170,156 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(14, value14: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(15, value15: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             throw new InvalidOperationException();
         }
@@ -347,22 +350,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -375,22 +378,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -403,22 +406,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -431,22 +434,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -459,22 +462,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -487,22 +490,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -515,22 +518,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -543,22 +546,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -571,22 +574,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -599,22 +602,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -627,22 +630,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -655,22 +658,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -683,22 +686,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -711,22 +714,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -739,22 +742,22 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -767,436 +770,436 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
+                14 => _value14!,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
+                15 => _value15!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1226,7 +1229,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT16.generated.cs
+++ b/OneOf.Extended/OneOfT16.generated.cs
@@ -1,30 +1,33 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default)
         {
             _index = index;
             _value0 = value0;
@@ -46,7 +49,7 @@ namespace OneOf
             _value16 = value16;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -91,71 +94,71 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(0, value0: t);
@@ -176,165 +179,165 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(15, value15: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(16, value16: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             throw new InvalidOperationException();
         }
@@ -366,23 +369,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -395,23 +398,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -424,23 +427,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -453,23 +456,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -482,23 +485,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -511,23 +514,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -540,23 +543,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -569,23 +572,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -598,23 +601,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -627,23 +630,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -656,23 +659,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -685,23 +688,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -714,23 +717,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -743,23 +746,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -772,23 +775,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -801,23 +804,23 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -830,480 +833,480 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
+                15 => _value15!,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
+                16 => _value16!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1334,7 +1337,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT17.generated.cs
+++ b/OneOf.Extended/OneOfT17.generated.cs
@@ -1,31 +1,34 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default)
         {
             _index = index;
             _value0 = value0;
@@ -48,7 +51,7 @@ namespace OneOf
             _value17 = value17;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -95,75 +98,75 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(0, value0: t);
@@ -185,174 +188,174 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(16, value16: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(17, value17: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             throw new InvalidOperationException();
         }
@@ -385,24 +388,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -415,24 +418,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -445,24 +448,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -475,24 +478,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -505,24 +508,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -535,24 +538,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -565,24 +568,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -595,24 +598,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -625,24 +628,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -655,24 +658,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -685,24 +688,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -715,24 +718,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -745,24 +748,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -775,24 +778,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -805,24 +808,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -835,24 +838,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -865,24 +868,24 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -895,526 +898,526 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
+                16 => _value16!,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
+                17 => _value17!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1446,7 +1449,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT18.generated.cs
+++ b/OneOf.Extended/OneOfT18.generated.cs
@@ -1,32 +1,35 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default)
         {
             _index = index;
             _value0 = value0;
@@ -50,7 +53,7 @@ namespace OneOf
             _value18 = value18;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -99,79 +102,79 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(0, value0: t);
@@ -194,183 +197,183 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(17, value17: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(18, value18: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             throw new InvalidOperationException();
         }
@@ -404,25 +407,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -435,25 +438,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -466,25 +469,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -497,25 +500,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -528,25 +531,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -559,25 +562,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -590,25 +593,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -621,25 +624,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -652,25 +655,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -683,25 +686,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -714,25 +717,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -745,25 +748,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -776,25 +779,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -807,25 +810,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -838,25 +841,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -869,25 +872,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -900,25 +903,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -931,25 +934,25 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -962,574 +965,574 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
+                17 => _value17!,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
+                18 => _value18!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1562,7 +1565,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT19.generated.cs
+++ b/OneOf.Extended/OneOfT19.generated.cs
@@ -1,33 +1,36 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default)
         {
             _index = index;
             _value0 = value0;
@@ -52,7 +55,7 @@ namespace OneOf
             _value19 = value19;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -103,83 +106,83 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(0, value0: t);
@@ -203,192 +206,192 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(18, value18: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(19, value19: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             throw new InvalidOperationException();
         }
@@ -423,26 +426,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -455,26 +458,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -487,26 +490,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -519,26 +522,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -551,26 +554,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -583,26 +586,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -615,26 +618,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -647,26 +650,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -679,26 +682,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -711,26 +714,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -743,26 +746,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -775,26 +778,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -807,26 +810,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -839,26 +842,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -871,26 +874,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -903,26 +906,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -935,26 +938,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -967,26 +970,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -999,26 +1002,26 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1031,624 +1034,624 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
+                18 => _value18!,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
+                19 => _value19!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1682,7 +1685,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT20.generated.cs
+++ b/OneOf.Extended/OneOfT20.generated.cs
@@ -1,34 +1,37 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default)
         {
             _index = index;
             _value0 = value0;
@@ -54,7 +57,7 @@ namespace OneOf
             _value20 = value20;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -107,87 +110,87 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(0, value0: t);
@@ -212,201 +215,201 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(19, value19: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(20, value20: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             throw new InvalidOperationException();
         }
@@ -442,27 +445,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -475,27 +478,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -508,27 +511,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -541,27 +544,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -574,27 +577,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -607,27 +610,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -640,27 +643,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -673,27 +676,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -706,27 +709,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -739,27 +742,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -772,27 +775,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -805,27 +808,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -838,27 +841,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -871,27 +874,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -904,27 +907,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -937,27 +940,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -970,27 +973,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1003,27 +1006,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1036,27 +1039,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1069,27 +1072,27 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1102,676 +1105,676 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
+                19 => _value19!,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
+                20 => _value20!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1806,7 +1809,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT21.generated.cs
+++ b/OneOf.Extended/OneOfT21.generated.cs
@@ -1,35 +1,38 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default)
         {
             _index = index;
             _value0 = value0;
@@ -56,7 +59,7 @@ namespace OneOf
             _value21 = value21;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -111,91 +114,91 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(0, value0: t);
@@ -221,210 +224,210 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(20, value20: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(21, value21: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             throw new InvalidOperationException();
         }
@@ -461,28 +464,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -495,28 +498,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -529,28 +532,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -563,28 +566,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -597,28 +600,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -631,28 +634,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -665,28 +668,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -699,28 +702,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -733,28 +736,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -767,28 +770,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -801,28 +804,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -835,28 +838,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -869,28 +872,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -903,28 +906,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -937,28 +940,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -971,28 +974,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1005,28 +1008,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1039,28 +1042,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1073,28 +1076,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1107,28 +1110,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1141,28 +1144,28 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1175,730 +1178,730 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
+                20 => _value20!,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
+                21 => _value21!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -1934,7 +1937,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT22.generated.cs
+++ b/OneOf.Extended/OneOfT22.generated.cs
@@ -1,36 +1,39 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default, T22? value22 = default)
         {
             _index = index;
             _value0 = value0;
@@ -58,7 +61,7 @@ namespace OneOf
             _value22 = value22;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -115,95 +118,95 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(0, value0: t);
@@ -230,219 +233,219 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(21, value21: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(22, value22: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             throw new InvalidOperationException();
         }
@@ -480,29 +483,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -515,29 +518,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -550,29 +553,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -585,29 +588,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -620,29 +623,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -655,29 +658,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -690,29 +693,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -725,29 +728,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -760,29 +763,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -795,29 +798,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -830,29 +833,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -865,29 +868,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -900,29 +903,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -935,29 +938,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -970,29 +973,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1005,29 +1008,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1040,29 +1043,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1075,29 +1078,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1110,29 +1113,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1145,29 +1148,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1180,29 +1183,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1215,29 +1218,29 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1250,786 +1253,786 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => mapFunc(_value22!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
+                21 => _value21!,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
+                22 => _value22!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -2066,7 +2069,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT23.generated.cs
+++ b/OneOf.Extended/OneOfT23.generated.cs
@@ -1,37 +1,40 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default, T22? value22 = default, T23? value23 = default)
         {
             _index = index;
             _value0 = value0;
@@ -60,7 +63,7 @@ namespace OneOf
             _value23 = value23;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -119,99 +122,99 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(0, value0: t);
@@ -239,228 +242,228 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(22, value22: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(23, value23: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             throw new InvalidOperationException();
         }
@@ -499,30 +502,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -535,30 +538,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -571,30 +574,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -607,30 +610,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -643,30 +646,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -679,30 +682,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -715,30 +718,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -751,30 +754,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -787,30 +790,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -823,30 +826,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -859,30 +862,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -895,30 +898,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -931,30 +934,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -967,30 +970,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1003,30 +1006,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1039,30 +1042,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1075,30 +1078,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1111,30 +1114,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1147,30 +1150,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1183,30 +1186,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1219,30 +1222,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1255,30 +1258,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1291,30 +1294,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => mapFunc(_value22!),
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1327,844 +1330,844 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => mapFunc(_value23!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
+                22 => _value22!,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
+                23 => _value23!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -2202,7 +2205,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT24.generated.cs
+++ b/OneOf.Extended/OneOfT24.generated.cs
@@ -1,38 +1,41 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default, T22? value22 = default, T23? value23 = default, T24? value24 = default)
         {
             _index = index;
             _value0 = value0;
@@ -62,7 +65,7 @@ namespace OneOf
             _value24 = value24;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -123,103 +126,103 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(0, value0: t);
@@ -248,237 +251,237 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(23, value23: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T24 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(24, value24: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             throw new InvalidOperationException();
         }
@@ -518,31 +521,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -555,31 +558,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -592,31 +595,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -629,31 +632,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -666,31 +669,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -703,31 +706,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -740,31 +743,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -777,31 +780,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -814,31 +817,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -851,31 +854,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -888,31 +891,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -925,31 +928,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -962,31 +965,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -999,31 +1002,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1036,31 +1039,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1073,31 +1076,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1110,31 +1113,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1147,31 +1150,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1184,31 +1187,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1221,31 +1224,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1258,31 +1261,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1295,31 +1298,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1332,31 +1335,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => mapFunc(_value22!),
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1369,31 +1372,31 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => mapFunc(_value23!),
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1406,904 +1409,904 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => mapFunc(_value24!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
+                23 => _value23!,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
+                24 => _value24!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -2342,7 +2345,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT25.generated.cs
+++ b/OneOf.Extended/OneOfT25.generated.cs
@@ -1,39 +1,42 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default, T22? value22 = default, T23? value23 = default, T24? value24 = default, T25? value25 = default)
         {
             _index = index;
             _value0 = value0;
@@ -64,7 +67,7 @@ namespace OneOf
             _value25 = value25;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -127,107 +130,107 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(0, value0: t);
@@ -257,246 +260,246 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T24 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(24, value24: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T25 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(25, value25: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             throw new InvalidOperationException();
         }
@@ -537,32 +540,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -575,32 +578,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -613,32 +616,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -651,32 +654,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -689,32 +692,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -727,32 +730,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -765,32 +768,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -803,32 +806,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -841,32 +844,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -879,32 +882,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -917,32 +920,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -955,32 +958,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -993,32 +996,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1031,32 +1034,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1069,32 +1072,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1107,32 +1110,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1145,32 +1148,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1183,32 +1186,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1221,32 +1224,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1259,32 +1262,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1297,32 +1300,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1335,32 +1338,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1373,32 +1376,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => mapFunc(_value22!),
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1411,32 +1414,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => mapFunc(_value23!),
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1449,32 +1452,32 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => mapFunc(_value24!),
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1487,966 +1490,966 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => mapFunc(_value25!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
+                24 => _value24!,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
+                25 => _value25!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -2486,7 +2489,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT26.generated.cs
+++ b/OneOf.Extended/OneOfT26.generated.cs
@@ -1,40 +1,43 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default, T22? value22 = default, T23? value23 = default, T24? value24 = default, T25? value25 = default, T26? value26 = default)
         {
             _index = index;
             _value0 = value0;
@@ -66,7 +69,7 @@ namespace OneOf
             _value26 = value26;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -131,111 +134,111 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(0, value0: t);
@@ -266,255 +269,255 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T25 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(25, value25: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T26 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(26, value26: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             throw new InvalidOperationException();
         }
@@ -556,33 +559,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -595,33 +598,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -634,33 +637,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -673,33 +676,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -712,33 +715,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -751,33 +754,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -790,33 +793,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -829,33 +832,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -868,33 +871,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -907,33 +910,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -946,33 +949,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -985,33 +988,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1024,33 +1027,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1063,33 +1066,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1102,33 +1105,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1141,33 +1144,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1180,33 +1183,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1219,33 +1222,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1258,33 +1261,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1297,33 +1300,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1336,33 +1339,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1375,33 +1378,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1414,33 +1417,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => mapFunc(_value22!),
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1453,33 +1456,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => mapFunc(_value23!),
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1492,33 +1495,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => mapFunc(_value24!),
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1531,33 +1534,33 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => mapFunc(_value25!),
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1570,1030 +1573,1030 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => mapFunc(_value26!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
+                25 => _value25!,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
+                26 => _value26!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -2634,7 +2637,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT27.generated.cs
+++ b/OneOf.Extended/OneOfT27.generated.cs
@@ -1,41 +1,44 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
-        readonly T27 _value27;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
+        readonly T27? _value27;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default, T22? value22 = default, T23? value23 = default, T24? value24 = default, T25? value25 = default, T26? value26 = default, T27? value27 = default)
         {
             _index = index;
             _value0 = value0;
@@ -68,7 +71,7 @@ namespace OneOf
             _value27 = value27;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -135,115 +138,115 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
         public T27 AsT27 =>
             _index == 27 ?
-                _value27 :
+                _value27! :
                 throw new InvalidOperationException($"Cannot return as T27 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(0, value0: t);
@@ -275,264 +278,264 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T26 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(26, value26: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T27 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(27, value27: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26, Action<T27>? f27)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             if (_index == 27 && f27 != null)
             {
-                f27(_value27);
+                f27(_value27!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26, Func<T27, TResult>? f27)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             if (_index == 27 && f27 != null)
             {
-                return f27(_value27);
+                return f27(_value27!);
             }
             throw new InvalidOperationException();
         }
@@ -575,34 +578,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -615,34 +618,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -655,34 +658,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -695,34 +698,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -735,34 +738,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -775,34 +778,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -815,34 +818,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -855,34 +858,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -895,34 +898,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -935,34 +938,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -975,34 +978,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1015,34 +1018,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1055,34 +1058,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1095,34 +1098,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1135,34 +1138,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1175,34 +1178,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1215,34 +1218,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1255,34 +1258,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1295,34 +1298,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1335,34 +1338,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1375,34 +1378,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1415,34 +1418,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1455,34 +1458,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => mapFunc(_value22!),
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1495,34 +1498,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => mapFunc(_value23!),
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1535,34 +1538,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => mapFunc(_value24!),
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1575,34 +1578,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => mapFunc(_value25!),
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1615,34 +1618,34 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => mapFunc(_value26!),
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1655,1096 +1658,1096 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => mapFunc(AsT27),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => mapFunc(_value27!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
-                27 => AsT27,
+                26 => _value26!,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
-                27 => AsT27,
+                27 => _value27!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT26;
 		}
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+		public bool TryPickT27([MaybeNullWhen(false)] out T27 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
 		{
 			value = IsT27 ? AsT27 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 27 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -2786,7 +2789,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT28.generated.cs
+++ b/OneOf.Extended/OneOfT28.generated.cs
@@ -1,42 +1,45 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
-        readonly T27 _value27;
-        readonly T28 _value28;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
+        readonly T27? _value27;
+        readonly T28? _value28;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default, T22? value22 = default, T23? value23 = default, T24? value24 = default, T25? value25 = default, T26? value26 = default, T27? value27 = default, T28? value28 = default)
         {
             _index = index;
             _value0 = value0;
@@ -70,7 +73,7 @@ namespace OneOf
             _value28 = value28;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -139,119 +142,119 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
         public T27 AsT27 =>
             _index == 27 ?
-                _value27 :
+                _value27! :
                 throw new InvalidOperationException($"Cannot return as T27 as result is T{_index}");
         public T28 AsT28 =>
             _index == 28 ?
-                _value28 :
+                _value28! :
                 throw new InvalidOperationException($"Cannot return as T28 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(0, value0: t);
@@ -284,273 +287,273 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T27 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(27, value27: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T28 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(28, value28: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26, Action<T27>? f27, Action<T28>? f28)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             if (_index == 27 && f27 != null)
             {
-                f27(_value27);
+                f27(_value27!);
                 return;
             }
             if (_index == 28 && f28 != null)
             {
-                f28(_value28);
+                f28(_value28!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26, Func<T27, TResult>? f27, Func<T28, TResult>? f28)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             if (_index == 27 && f27 != null)
             {
-                return f27(_value27);
+                return f27(_value27!);
             }
             if (_index == 28 && f28 != null)
             {
-                return f28(_value28);
+                return f28(_value28!);
             }
             throw new InvalidOperationException();
         }
@@ -594,35 +597,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -635,35 +638,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -676,35 +679,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -717,35 +720,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -758,35 +761,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -799,35 +802,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -840,35 +843,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -881,35 +884,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -922,35 +925,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -963,35 +966,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1004,35 +1007,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1045,35 +1048,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1086,35 +1089,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1127,35 +1130,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1168,35 +1171,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1209,35 +1212,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1250,35 +1253,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1291,35 +1294,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1332,35 +1335,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1373,35 +1376,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1414,35 +1417,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1455,35 +1458,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1496,35 +1499,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => mapFunc(_value22!),
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1537,35 +1540,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => mapFunc(_value23!),
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1578,35 +1581,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => mapFunc(_value24!),
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1619,35 +1622,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => mapFunc(_value25!),
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1660,35 +1663,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => mapFunc(_value26!),
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1701,35 +1704,35 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => mapFunc(AsT27),
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => mapFunc(_value27!),
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1742,1164 +1745,1164 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => mapFunc(AsT28),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => mapFunc(_value28!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
-                27 => AsT27,
-                28 => AsT28,
+                27 => _value27!,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT26;
 		}
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28> remainder)
+		public bool TryPickT27([MaybeNullWhen(false)] out T27 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28> remainder)
 		{
 			value = IsT27 ? AsT27 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 27 => default,
-                28 => AsT28,
+                28 => _value28!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT27;
 		}
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+		public bool TryPickT28([MaybeNullWhen(false)] out T28 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
 		{
 			value = IsT28 ? AsT28 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 28 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -2942,7 +2945,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT29.generated.cs
+++ b/OneOf.Extended/OneOfT29.generated.cs
@@ -1,43 +1,46 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
-        readonly T27 _value27;
-        readonly T28 _value28;
-        readonly T29 _value29;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
+        readonly T27? _value27;
+        readonly T28? _value28;
+        readonly T29? _value29;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default, T29 value29 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default, T22? value22 = default, T23? value23 = default, T24? value24 = default, T25? value25 = default, T26? value26 = default, T27? value27 = default, T28? value28 = default, T29? value29 = default)
         {
             _index = index;
             _value0 = value0;
@@ -72,7 +75,7 @@ namespace OneOf
             _value29 = value29;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -143,123 +146,123 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
         public T27 AsT27 =>
             _index == 27 ?
-                _value27 :
+                _value27! :
                 throw new InvalidOperationException($"Cannot return as T27 as result is T{_index}");
         public T28 AsT28 =>
             _index == 28 ?
-                _value28 :
+                _value28! :
                 throw new InvalidOperationException($"Cannot return as T28 as result is T{_index}");
         public T29 AsT29 =>
             _index == 29 ?
-                _value29 :
+                _value29! :
                 throw new InvalidOperationException($"Cannot return as T29 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(0, value0: t);
@@ -293,282 +296,282 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T28 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(28, value28: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T29 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(29, value29: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26, Action<T27>? f27, Action<T28>? f28, Action<T29>? f29)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             if (_index == 27 && f27 != null)
             {
-                f27(_value27);
+                f27(_value27!);
                 return;
             }
             if (_index == 28 && f28 != null)
             {
-                f28(_value28);
+                f28(_value28!);
                 return;
             }
             if (_index == 29 && f29 != null)
             {
-                f29(_value29);
+                f29(_value29!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26, Func<T27, TResult>? f27, Func<T28, TResult>? f28, Func<T29, TResult>? f29)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             if (_index == 27 && f27 != null)
             {
-                return f27(_value27);
+                return f27(_value27!);
             }
             if (_index == 28 && f28 != null)
             {
-                return f28(_value28);
+                return f28(_value28!);
             }
             if (_index == 29 && f29 != null)
             {
-                return f29(_value29);
+                return f29(_value29!);
             }
             throw new InvalidOperationException();
         }
@@ -613,36 +616,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -655,36 +658,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -697,36 +700,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -739,36 +742,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -781,36 +784,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -823,36 +826,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -865,36 +868,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -907,36 +910,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -949,36 +952,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -991,36 +994,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1033,36 +1036,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1075,36 +1078,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1117,36 +1120,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1159,36 +1162,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1201,36 +1204,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1243,36 +1246,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1285,36 +1288,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1327,36 +1330,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1369,36 +1372,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1411,36 +1414,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1453,36 +1456,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1495,36 +1498,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1537,36 +1540,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => mapFunc(_value22!),
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1579,36 +1582,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => mapFunc(_value23!),
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1621,36 +1624,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => mapFunc(_value24!),
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1663,36 +1666,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => mapFunc(_value25!),
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1705,36 +1708,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => mapFunc(_value26!),
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1747,36 +1750,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => mapFunc(AsT27),
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => mapFunc(_value27!),
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1789,36 +1792,36 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => mapFunc(AsT28),
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => mapFunc(_value28!),
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1831,1234 +1834,1234 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => mapFunc(AsT29),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => mapFunc(_value29!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT26;
 		}
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29> remainder)
+		public bool TryPickT27([MaybeNullWhen(false)] out T27 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29> remainder)
 		{
 			value = IsT27 ? AsT27 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 27 => default,
-                28 => AsT28,
-                29 => AsT29,
+                28 => _value28!,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT27;
 		}
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29> remainder)
+		public bool TryPickT28([MaybeNullWhen(false)] out T28 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29> remainder)
 		{
 			value = IsT28 ? AsT28 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 28 => default,
-                29 => AsT29,
+                29 => _value29!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT28;
 		}
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+		public bool TryPickT29([MaybeNullWhen(false)] out T29 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
 		{
 			value = IsT29 ? AsT29 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 29 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -3102,7 +3105,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT30.generated.cs
+++ b/OneOf.Extended/OneOfT30.generated.cs
@@ -1,44 +1,47 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
-        readonly T27 _value27;
-        readonly T28 _value28;
-        readonly T29 _value29;
-        readonly T30 _value30;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
+        readonly T27? _value27;
+        readonly T28? _value28;
+        readonly T29? _value29;
+        readonly T30? _value30;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default, T29 value29 = default, T30 value30 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default, T22? value22 = default, T23? value23 = default, T24? value24 = default, T25? value25 = default, T26? value26 = default, T27? value27 = default, T28? value28 = default, T29? value29 = default, T30? value30 = default)
         {
             _index = index;
             _value0 = value0;
@@ -74,7 +77,7 @@ namespace OneOf
             _value30 = value30;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -147,127 +150,127 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
         public T27 AsT27 =>
             _index == 27 ?
-                _value27 :
+                _value27! :
                 throw new InvalidOperationException($"Cannot return as T27 as result is T{_index}");
         public T28 AsT28 =>
             _index == 28 ?
-                _value28 :
+                _value28! :
                 throw new InvalidOperationException($"Cannot return as T28 as result is T{_index}");
         public T29 AsT29 =>
             _index == 29 ?
-                _value29 :
+                _value29! :
                 throw new InvalidOperationException($"Cannot return as T29 as result is T{_index}");
         public T30 AsT30 =>
             _index == 30 ?
-                _value30 :
+                _value30! :
                 throw new InvalidOperationException($"Cannot return as T30 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(0, value0: t);
@@ -302,291 +305,291 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T29 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(29, value29: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T30 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(30, value30: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29, Action<T30> f30)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26, Action<T27>? f27, Action<T28>? f28, Action<T29>? f29, Action<T30>? f30)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             if (_index == 27 && f27 != null)
             {
-                f27(_value27);
+                f27(_value27!);
                 return;
             }
             if (_index == 28 && f28 != null)
             {
-                f28(_value28);
+                f28(_value28!);
                 return;
             }
             if (_index == 29 && f29 != null)
             {
-                f29(_value29);
+                f29(_value29!);
                 return;
             }
             if (_index == 30 && f30 != null)
             {
-                f30(_value30);
+                f30(_value30!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29, Func<T30, TResult> f30)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26, Func<T27, TResult>? f27, Func<T28, TResult>? f28, Func<T29, TResult>? f29, Func<T30, TResult>? f30)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             if (_index == 27 && f27 != null)
             {
-                return f27(_value27);
+                return f27(_value27!);
             }
             if (_index == 28 && f28 != null)
             {
-                return f28(_value28);
+                return f28(_value28!);
             }
             if (_index == 29 && f29 != null)
             {
-                return f29(_value29);
+                return f29(_value29!);
             }
             if (_index == 30 && f30 != null)
             {
-                return f30(_value30);
+                return f30(_value30!);
             }
             throw new InvalidOperationException();
         }
@@ -632,37 +635,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -675,37 +678,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -718,37 +721,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -761,37 +764,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -804,37 +807,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -847,37 +850,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -890,37 +893,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -933,37 +936,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -976,37 +979,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1019,37 +1022,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1062,37 +1065,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1105,37 +1108,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1148,37 +1151,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1191,37 +1194,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1234,37 +1237,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1277,37 +1280,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1320,37 +1323,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1363,37 +1366,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1406,37 +1409,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1449,37 +1452,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1492,37 +1495,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1535,37 +1538,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1578,37 +1581,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => mapFunc(_value22!),
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1621,37 +1624,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => mapFunc(_value23!),
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1664,37 +1667,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => mapFunc(_value24!),
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1707,37 +1710,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => mapFunc(_value25!),
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1750,37 +1753,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => mapFunc(_value26!),
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1793,37 +1796,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => mapFunc(AsT27),
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => mapFunc(_value27!),
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1836,37 +1839,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => mapFunc(AsT28),
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => mapFunc(_value28!),
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1879,37 +1882,37 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => mapFunc(AsT29),
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => mapFunc(_value29!),
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1922,1306 +1925,1306 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => mapFunc(AsT30),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => mapFunc(_value30!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT26;
 		}
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30> remainder)
+		public bool TryPickT27([MaybeNullWhen(false)] out T27 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30> remainder)
 		{
 			value = IsT27 ? AsT27 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 27 => default,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT27;
 		}
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30> remainder)
+		public bool TryPickT28([MaybeNullWhen(false)] out T28 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30> remainder)
 		{
 			value = IsT28 ? AsT28 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 28 => default,
-                29 => AsT29,
-                30 => AsT30,
+                29 => _value29!,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT28;
 		}
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30> remainder)
+		public bool TryPickT29([MaybeNullWhen(false)] out T29 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30> remainder)
 		{
 			value = IsT29 ? AsT29 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 29 => default,
-                30 => AsT30,
+                30 => _value30!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT29;
 		}
         
-		public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+		public bool TryPickT30([MaybeNullWhen(false)] out T30 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
 		{
 			value = IsT30 ? AsT30 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 30 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -3266,7 +3269,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT31.generated.cs
+++ b/OneOf.Extended/OneOfT31.generated.cs
@@ -1,45 +1,48 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
-        readonly T10 _value10;
-        readonly T11 _value11;
-        readonly T12 _value12;
-        readonly T13 _value13;
-        readonly T14 _value14;
-        readonly T15 _value15;
-        readonly T16 _value16;
-        readonly T17 _value17;
-        readonly T18 _value18;
-        readonly T19 _value19;
-        readonly T20 _value20;
-        readonly T21 _value21;
-        readonly T22 _value22;
-        readonly T23 _value23;
-        readonly T24 _value24;
-        readonly T25 _value25;
-        readonly T26 _value26;
-        readonly T27 _value27;
-        readonly T28 _value28;
-        readonly T29 _value29;
-        readonly T30 _value30;
-        readonly T31 _value31;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
+        readonly T10? _value10;
+        readonly T11? _value11;
+        readonly T12? _value12;
+        readonly T13? _value13;
+        readonly T14? _value14;
+        readonly T15? _value15;
+        readonly T16? _value16;
+        readonly T17? _value17;
+        readonly T18? _value18;
+        readonly T19? _value19;
+        readonly T20? _value20;
+        readonly T21? _value21;
+        readonly T22? _value22;
+        readonly T23? _value23;
+        readonly T24? _value24;
+        readonly T25? _value25;
+        readonly T26? _value26;
+        readonly T27? _value27;
+        readonly T28? _value28;
+        readonly T29? _value29;
+        readonly T30? _value30;
+        readonly T31? _value31;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default, T29 value29 = default, T30 value30 = default, T31 value31 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default, T10? value10 = default, T11? value11 = default, T12? value12 = default, T13? value13 = default, T14? value14 = default, T15? value15 = default, T16? value16 = default, T17? value17 = default, T18? value18 = default, T19? value19 = default, T20? value20 = default, T21? value21 = default, T22? value22 = default, T23? value23 = default, T24? value24 = default, T25? value25 = default, T26? value26 = default, T27? value27 = default, T28? value28 = default, T29? value29 = default, T30? value30 = default, T31? value31 = default)
         {
             _index = index;
             _value0 = value0;
@@ -76,7 +79,7 @@ namespace OneOf
             _value31 = value31;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -151,131 +154,131 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
         public T10 AsT10 =>
             _index == 10 ?
-                _value10 :
+                _value10! :
                 throw new InvalidOperationException($"Cannot return as T10 as result is T{_index}");
         public T11 AsT11 =>
             _index == 11 ?
-                _value11 :
+                _value11! :
                 throw new InvalidOperationException($"Cannot return as T11 as result is T{_index}");
         public T12 AsT12 =>
             _index == 12 ?
-                _value12 :
+                _value12! :
                 throw new InvalidOperationException($"Cannot return as T12 as result is T{_index}");
         public T13 AsT13 =>
             _index == 13 ?
-                _value13 :
+                _value13! :
                 throw new InvalidOperationException($"Cannot return as T13 as result is T{_index}");
         public T14 AsT14 =>
             _index == 14 ?
-                _value14 :
+                _value14! :
                 throw new InvalidOperationException($"Cannot return as T14 as result is T{_index}");
         public T15 AsT15 =>
             _index == 15 ?
-                _value15 :
+                _value15! :
                 throw new InvalidOperationException($"Cannot return as T15 as result is T{_index}");
         public T16 AsT16 =>
             _index == 16 ?
-                _value16 :
+                _value16! :
                 throw new InvalidOperationException($"Cannot return as T16 as result is T{_index}");
         public T17 AsT17 =>
             _index == 17 ?
-                _value17 :
+                _value17! :
                 throw new InvalidOperationException($"Cannot return as T17 as result is T{_index}");
         public T18 AsT18 =>
             _index == 18 ?
-                _value18 :
+                _value18! :
                 throw new InvalidOperationException($"Cannot return as T18 as result is T{_index}");
         public T19 AsT19 =>
             _index == 19 ?
-                _value19 :
+                _value19! :
                 throw new InvalidOperationException($"Cannot return as T19 as result is T{_index}");
         public T20 AsT20 =>
             _index == 20 ?
-                _value20 :
+                _value20! :
                 throw new InvalidOperationException($"Cannot return as T20 as result is T{_index}");
         public T21 AsT21 =>
             _index == 21 ?
-                _value21 :
+                _value21! :
                 throw new InvalidOperationException($"Cannot return as T21 as result is T{_index}");
         public T22 AsT22 =>
             _index == 22 ?
-                _value22 :
+                _value22! :
                 throw new InvalidOperationException($"Cannot return as T22 as result is T{_index}");
         public T23 AsT23 =>
             _index == 23 ?
-                _value23 :
+                _value23! :
                 throw new InvalidOperationException($"Cannot return as T23 as result is T{_index}");
         public T24 AsT24 =>
             _index == 24 ?
-                _value24 :
+                _value24! :
                 throw new InvalidOperationException($"Cannot return as T24 as result is T{_index}");
         public T25 AsT25 =>
             _index == 25 ?
-                _value25 :
+                _value25! :
                 throw new InvalidOperationException($"Cannot return as T25 as result is T{_index}");
         public T26 AsT26 =>
             _index == 26 ?
-                _value26 :
+                _value26! :
                 throw new InvalidOperationException($"Cannot return as T26 as result is T{_index}");
         public T27 AsT27 =>
             _index == 27 ?
-                _value27 :
+                _value27! :
                 throw new InvalidOperationException($"Cannot return as T27 as result is T{_index}");
         public T28 AsT28 =>
             _index == 28 ?
-                _value28 :
+                _value28! :
                 throw new InvalidOperationException($"Cannot return as T28 as result is T{_index}");
         public T29 AsT29 =>
             _index == 29 ?
-                _value29 :
+                _value29! :
                 throw new InvalidOperationException($"Cannot return as T29 as result is T{_index}");
         public T30 AsT30 =>
             _index == 30 ?
-                _value30 :
+                _value30! :
                 throw new InvalidOperationException($"Cannot return as T30 as result is T{_index}");
         public T31 AsT31 =>
             _index == 31 ?
-                _value31 :
+                _value31! :
                 throw new InvalidOperationException($"Cannot return as T31 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(0, value0: t);
@@ -311,300 +314,300 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T30 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(30, value30: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T31 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(31, value31: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29, Action<T30> f30, Action<T31> f31)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9, Action<T10>? f10, Action<T11>? f11, Action<T12>? f12, Action<T13>? f13, Action<T14>? f14, Action<T15>? f15, Action<T16>? f16, Action<T17>? f17, Action<T18>? f18, Action<T19>? f19, Action<T20>? f20, Action<T21>? f21, Action<T22>? f22, Action<T23>? f23, Action<T24>? f24, Action<T25>? f25, Action<T26>? f26, Action<T27>? f27, Action<T28>? f28, Action<T29>? f29, Action<T30>? f30, Action<T31>? f31)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             if (_index == 10 && f10 != null)
             {
-                f10(_value10);
+                f10(_value10!);
                 return;
             }
             if (_index == 11 && f11 != null)
             {
-                f11(_value11);
+                f11(_value11!);
                 return;
             }
             if (_index == 12 && f12 != null)
             {
-                f12(_value12);
+                f12(_value12!);
                 return;
             }
             if (_index == 13 && f13 != null)
             {
-                f13(_value13);
+                f13(_value13!);
                 return;
             }
             if (_index == 14 && f14 != null)
             {
-                f14(_value14);
+                f14(_value14!);
                 return;
             }
             if (_index == 15 && f15 != null)
             {
-                f15(_value15);
+                f15(_value15!);
                 return;
             }
             if (_index == 16 && f16 != null)
             {
-                f16(_value16);
+                f16(_value16!);
                 return;
             }
             if (_index == 17 && f17 != null)
             {
-                f17(_value17);
+                f17(_value17!);
                 return;
             }
             if (_index == 18 && f18 != null)
             {
-                f18(_value18);
+                f18(_value18!);
                 return;
             }
             if (_index == 19 && f19 != null)
             {
-                f19(_value19);
+                f19(_value19!);
                 return;
             }
             if (_index == 20 && f20 != null)
             {
-                f20(_value20);
+                f20(_value20!);
                 return;
             }
             if (_index == 21 && f21 != null)
             {
-                f21(_value21);
+                f21(_value21!);
                 return;
             }
             if (_index == 22 && f22 != null)
             {
-                f22(_value22);
+                f22(_value22!);
                 return;
             }
             if (_index == 23 && f23 != null)
             {
-                f23(_value23);
+                f23(_value23!);
                 return;
             }
             if (_index == 24 && f24 != null)
             {
-                f24(_value24);
+                f24(_value24!);
                 return;
             }
             if (_index == 25 && f25 != null)
             {
-                f25(_value25);
+                f25(_value25!);
                 return;
             }
             if (_index == 26 && f26 != null)
             {
-                f26(_value26);
+                f26(_value26!);
                 return;
             }
             if (_index == 27 && f27 != null)
             {
-                f27(_value27);
+                f27(_value27!);
                 return;
             }
             if (_index == 28 && f28 != null)
             {
-                f28(_value28);
+                f28(_value28!);
                 return;
             }
             if (_index == 29 && f29 != null)
             {
-                f29(_value29);
+                f29(_value29!);
                 return;
             }
             if (_index == 30 && f30 != null)
             {
-                f30(_value30);
+                f30(_value30!);
                 return;
             }
             if (_index == 31 && f31 != null)
             {
-                f31(_value31);
+                f31(_value31!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29, Func<T30, TResult> f30, Func<T31, TResult> f31)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9, Func<T10, TResult>? f10, Func<T11, TResult>? f11, Func<T12, TResult>? f12, Func<T13, TResult>? f13, Func<T14, TResult>? f14, Func<T15, TResult>? f15, Func<T16, TResult>? f16, Func<T17, TResult>? f17, Func<T18, TResult>? f18, Func<T19, TResult>? f19, Func<T20, TResult>? f20, Func<T21, TResult>? f21, Func<T22, TResult>? f22, Func<T23, TResult>? f23, Func<T24, TResult>? f24, Func<T25, TResult>? f25, Func<T26, TResult>? f26, Func<T27, TResult>? f27, Func<T28, TResult>? f28, Func<T29, TResult>? f29, Func<T30, TResult>? f30, Func<T31, TResult>? f31)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             if (_index == 10 && f10 != null)
             {
-                return f10(_value10);
+                return f10(_value10!);
             }
             if (_index == 11 && f11 != null)
             {
-                return f11(_value11);
+                return f11(_value11!);
             }
             if (_index == 12 && f12 != null)
             {
-                return f12(_value12);
+                return f12(_value12!);
             }
             if (_index == 13 && f13 != null)
             {
-                return f13(_value13);
+                return f13(_value13!);
             }
             if (_index == 14 && f14 != null)
             {
-                return f14(_value14);
+                return f14(_value14!);
             }
             if (_index == 15 && f15 != null)
             {
-                return f15(_value15);
+                return f15(_value15!);
             }
             if (_index == 16 && f16 != null)
             {
-                return f16(_value16);
+                return f16(_value16!);
             }
             if (_index == 17 && f17 != null)
             {
-                return f17(_value17);
+                return f17(_value17!);
             }
             if (_index == 18 && f18 != null)
             {
-                return f18(_value18);
+                return f18(_value18!);
             }
             if (_index == 19 && f19 != null)
             {
-                return f19(_value19);
+                return f19(_value19!);
             }
             if (_index == 20 && f20 != null)
             {
-                return f20(_value20);
+                return f20(_value20!);
             }
             if (_index == 21 && f21 != null)
             {
-                return f21(_value21);
+                return f21(_value21!);
             }
             if (_index == 22 && f22 != null)
             {
-                return f22(_value22);
+                return f22(_value22!);
             }
             if (_index == 23 && f23 != null)
             {
-                return f23(_value23);
+                return f23(_value23!);
             }
             if (_index == 24 && f24 != null)
             {
-                return f24(_value24);
+                return f24(_value24!);
             }
             if (_index == 25 && f25 != null)
             {
-                return f25(_value25);
+                return f25(_value25!);
             }
             if (_index == 26 && f26 != null)
             {
-                return f26(_value26);
+                return f26(_value26!);
             }
             if (_index == 27 && f27 != null)
             {
-                return f27(_value27);
+                return f27(_value27!);
             }
             if (_index == 28 && f28 != null)
             {
-                return f28(_value28);
+                return f28(_value28!);
             }
             if (_index == 29 && f29 != null)
             {
-                return f29(_value29);
+                return f29(_value29!);
             }
             if (_index == 30 && f30 != null)
             {
-                return f30(_value30);
+                return f30(_value30!);
             }
             if (_index == 31 && f31 != null)
             {
-                return f31(_value31);
+                return f31(_value31!);
             }
             throw new InvalidOperationException();
         }
@@ -651,38 +654,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -695,38 +698,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -739,38 +742,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -783,38 +786,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -827,38 +830,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -871,38 +874,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -915,38 +918,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -959,38 +962,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1003,38 +1006,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1047,38 +1050,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1091,38 +1094,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => mapFunc(_value10!),
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1135,38 +1138,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => mapFunc(_value11!),
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1179,38 +1182,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => mapFunc(_value12!),
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1223,38 +1226,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => mapFunc(_value13!),
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1267,38 +1270,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => mapFunc(_value14!),
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1311,38 +1314,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => mapFunc(_value15!),
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1355,38 +1358,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => mapFunc(_value16!),
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1399,38 +1402,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => mapFunc(_value17!),
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1443,38 +1446,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => mapFunc(_value18!),
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1487,38 +1490,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => mapFunc(_value19!),
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1531,38 +1534,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => mapFunc(_value20!),
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1575,38 +1578,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => mapFunc(_value21!),
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1619,38 +1622,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => mapFunc(_value22!),
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1663,38 +1666,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => mapFunc(_value23!),
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1707,38 +1710,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => mapFunc(_value24!),
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1751,38 +1754,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => mapFunc(_value25!),
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1795,38 +1798,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => mapFunc(_value26!),
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1839,38 +1842,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => mapFunc(AsT27),
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => mapFunc(_value27!),
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1883,38 +1886,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => mapFunc(AsT28),
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => mapFunc(_value28!),
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1927,38 +1930,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => mapFunc(AsT29),
-                30 => AsT30,
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => mapFunc(_value29!),
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -1971,38 +1974,38 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => mapFunc(AsT30),
-                31 => AsT31,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => mapFunc(_value30!),
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -2015,1380 +2018,1380 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => mapFunc(AsT31),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => mapFunc(_value31!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT9;
 		}
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT10([MaybeNullWhen(false)] out T10 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT10 ? AsT10 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT10;
 		}
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT11([MaybeNullWhen(false)] out T11 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT11 ? AsT11 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
                 11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT11;
 		}
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT12([MaybeNullWhen(false)] out T12 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT12 ? AsT12 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
                 12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT12;
 		}
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT13([MaybeNullWhen(false)] out T13 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT13 ? AsT13 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
                 13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT13;
 		}
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT14([MaybeNullWhen(false)] out T14 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT14 ? AsT14 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
                 14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT14;
 		}
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT15([MaybeNullWhen(false)] out T15 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT15 ? AsT15 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
                 15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT15;
 		}
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT16([MaybeNullWhen(false)] out T16 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT16 ? AsT16 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
                 16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT16;
 		}
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT17([MaybeNullWhen(false)] out T17 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT17 ? AsT17 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
                 17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT17;
 		}
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT18([MaybeNullWhen(false)] out T18 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT18 ? AsT18 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
                 18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT18;
 		}
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT19([MaybeNullWhen(false)] out T19 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT19 ? AsT19 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
                 19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT19;
 		}
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT20([MaybeNullWhen(false)] out T20 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT20 ? AsT20 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
                 20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT20;
 		}
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT21([MaybeNullWhen(false)] out T21 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT21 ? AsT21 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
                 21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT21;
 		}
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT22([MaybeNullWhen(false)] out T22 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT22 ? AsT22 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
                 22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT22;
 		}
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT23([MaybeNullWhen(false)] out T23 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT23 ? AsT23 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
                 23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT23;
 		}
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT24([MaybeNullWhen(false)] out T24 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT24 ? AsT24 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
                 24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT24;
 		}
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT25([MaybeNullWhen(false)] out T25 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT25 ? AsT25 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
                 25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT25;
 		}
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30, T31> remainder)
+		public bool TryPickT26([MaybeNullWhen(false)] out T26 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30, T31> remainder)
 		{
 			value = IsT26 ? AsT26 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
                 26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT26;
 		}
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30, T31> remainder)
+		public bool TryPickT27([MaybeNullWhen(false)] out T27 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30, T31> remainder)
 		{
 			value = IsT27 ? AsT27 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
                 27 => default,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT27;
 		}
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30, T31> remainder)
+		public bool TryPickT28([MaybeNullWhen(false)] out T28 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30, T31> remainder)
 		{
 			value = IsT28 ? AsT28 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
                 28 => default,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
+                29 => _value29!,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT28;
 		}
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30, T31> remainder)
+		public bool TryPickT29([MaybeNullWhen(false)] out T29 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30, T31> remainder)
 		{
 			value = IsT29 ? AsT29 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
                 29 => default,
-                30 => AsT30,
-                31 => AsT31,
+                30 => _value30!,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT29;
 		}
         
-		public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T31> remainder)
+		public bool TryPickT30([MaybeNullWhen(false)] out T30 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T31> remainder)
 		{
 			value = IsT30 ? AsT30 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
                 30 => default,
-                31 => AsT31,
+                31 => _value31!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT30;
 		}
         
-		public bool TryPickT31(out T31 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+		public bool TryPickT31([MaybeNullWhen(false)] out T31 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
 		{
 			value = IsT31 ? AsT31 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
+                10 => _value10!,
+                11 => _value11!,
+                12 => _value12!,
+                13 => _value13!,
+                14 => _value14!,
+                15 => _value15!,
+                16 => _value16!,
+                17 => _value17!,
+                18 => _value18!,
+                19 => _value19!,
+                20 => _value20!,
+                21 => _value21!,
+                22 => _value22!,
+                23 => _value23!,
+                24 => _value24!,
+                25 => _value25!,
+                26 => _value26!,
+                27 => _value27!,
+                28 => _value28!,
+                29 => _value29!,
+                30 => _value30!,
                 31 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -3434,7 +3437,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.Extended/OneOfT9.generated.cs
+++ b/OneOf.Extended/OneOfT9.generated.cs
@@ -1,23 +1,26 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
-        readonly T9 _value9;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
+        readonly T9? _value9;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default, T9? value9 = default)
         {
             _index = index;
             _value0 = value0;
@@ -32,7 +35,7 @@ namespace OneOf
             _value9 = value9;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -63,43 +66,43 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
         public T9 AsT9 =>
             _index == 9 ?
-                _value9 :
+                _value9! :
                 throw new InvalidOperationException($"Cannot return as T9 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(0, value0: t);
@@ -113,102 +116,102 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(8, value8: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(9, value9: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8, Action<T9>? f9)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             if (_index == 9 && f9 != null)
             {
-                f9(_value9);
+                f9(_value9!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8, Func<T9, TResult>? f9)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             if (_index == 9 && f9 != null)
             {
-                return f9(_value9);
+                return f9(_value9!);
             }
             throw new InvalidOperationException();
         }
@@ -233,16 +236,16 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -255,16 +258,16 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -277,16 +280,16 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -299,16 +302,16 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -321,16 +324,16 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -343,16 +346,16 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -365,16 +368,16 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -387,16 +390,16 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -409,16 +412,16 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -431,214 +434,214 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => mapFunc(_value9!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
+                7 => _value7!,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
-                9 => AsT9,
+                8 => _value8!,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
-                9 => AsT9,
+                9 => _value9!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT8;
 		}
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> remainder)
+		public bool TryPickT9([MaybeNullWhen(false)] out T9 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> remainder)
 		{
 			value = IsT9 ? AsT9 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 9 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -662,7 +665,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf.FSharp/OneOf.FSharp.fsproj
+++ b/OneOf.FSharp/OneOf.FSharp.fsproj
@@ -1,8 +1,8 @@
-<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>OneOf.FSharp</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <Authors>Harry McIntyre</Authors>
     <Title>OneOf - Easy Discriminated Unions for c#</Title>
@@ -16,15 +16,11 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>OneOf.FSharp</PackageId>
     <Copyright>Harry McIntyre</Copyright>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="FsOneOf.fs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
-	  <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OneOf.SourceGenerator.AnalyzerTests/OneOf.SourceGenerator.AnalyzerTests.csproj
+++ b/OneOf.SourceGenerator.AnalyzerTests/OneOf.SourceGenerator.AnalyzerTests.csproj
@@ -1,22 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <SuppressTfmSupportBuildErrors>true</SuppressTfmSupportBuildErrors>
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/OneOf.SourceGenerator.Tests/OneOf.SourceGenerator.Tests.csproj
+++ b/OneOf.SourceGenerator.Tests/OneOf.SourceGenerator.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/OneOf.Tests/OneOf.Tests.csproj
+++ b/OneOf.Tests/OneOf.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFrameworks>net451;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OneOf.Tests/ToStringTests.cs
+++ b/OneOf.Tests/ToStringTests.cs
@@ -21,26 +21,28 @@ namespace OneOf.Tests
             }
         }
 
-        [TestCase("en-NZ", ExpectedResult = "System.DateTime: 2/01/2019 1:02:03 AM")]
-        [TestCase("en-US", ExpectedResult = "System.DateTime: 1/2/2019 1:02:03 AM")]
-        public string LeftSideFormatsWithCurrentCulture(string cultureName)
+        [TestCase("en-NZ", "System.DateTime: 2/01/2019 1:02:03 AM")]
+        [TestCase("en-US", "System.DateTime: 1/2/2019 1:02:03 AM")]
+        public void LeftSideFormatsWithCurrentCulture(string cultureName, string expectedResult)
         {
-            return RunInCulture(new CultureInfo(cultureName, false), () =>
-            {
-                OneOf<DateTime, string> a = new DateTime(2019, 1, 2, 1, 2, 3);
-                return a.ToString();
-            });
+            StringAssert.AreEqualIgnoringCase(expectedResult,
+                RunInCulture(new CultureInfo(cultureName, false), () =>
+                {
+                    OneOf<DateTime, string> a = new DateTime(2019, 1, 2, 1, 2, 3);
+                    return a.ToString();
+                }));
         }
 
-        [TestCase("en-NZ", ExpectedResult = "System.DateTime: 2/01/2019 1:02:03 AM")]
-        [TestCase("en-US", ExpectedResult = "System.DateTime: 1/2/2019 1:02:03 AM")]
-        public string RightSideFormatsWithCurrentCulture(string cultureName)
+        [TestCase("en-NZ", "System.DateTime: 2/01/2019 1:02:03 AM")]
+        [TestCase("en-US", "System.DateTime: 1/2/2019 1:02:03 AM")]
+        public void RightSideFormatsWithCurrentCulture(string cultureName, string expectedResult)
         {
-            return RunInCulture(new CultureInfo(cultureName, false), () =>
-            {
-                OneOf<string, DateTime> a = new DateTime(2019, 1, 2, 1, 2, 3);
-                return a.ToString();
-            });
+            StringAssert.AreEqualIgnoringCase(expectedResult,
+                RunInCulture(new CultureInfo(cultureName, false), () =>
+                {
+                    OneOf<string, DateTime> a = new DateTime(2019, 1, 2, 1, 2, 3);
+                    return a.ToString();
+                }));
         }
 
         [Test]
@@ -70,7 +72,11 @@ namespace OneOf.Tests
         {
             OneOf<OneOf<string, bool>, OneOf<bool, string>> nestedType = (OneOf<string, bool>)true;
 
+#if NET451
             Assert.AreEqual("OneOf.OneOf`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]: System.Boolean: True", nestedType.ToString());
+#else
+            Assert.AreEqual("OneOf.OneOf`2[[System.String, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Boolean, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]: System.Boolean: True", nestedType.ToString());
+#endif
         }
     }
 }

--- a/OneOf/AttributePolyfill.cs
+++ b/OneOf/AttributePolyfill.cs
@@ -1,0 +1,19 @@
+﻿#if !NETSTANDARD2_1 && !NETSTANDARD2_1_OR_GREATER && !NETCOREAPP2_1_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis {
+    /// <summary>Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.ReturnValue" />, the parameter may be <see langword="null" /> even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">The return value condition. If the method returns this value, the associated parameter may be <see langword="null" />.</param>
+        public MaybeNullWhenAttribute(bool returnValue) {
+            ReturnValue = returnValue;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        /// <returns>The return value condition. If the method returns this value, the associated parameter may be <see langword="null" />.</returns>
+        public bool ReturnValue { get; }
+    }
+}
+
+#endif

--- a/OneOf/IOneOf.cs
+++ b/OneOf/IOneOf.cs
@@ -2,7 +2,7 @@ namespace OneOf
 {
     public interface IOneOf 
     { 
-        object Value { get ; }
+        object? Value { get ; }
         int Index { get; }
     }
 }

--- a/OneOf/OneOf.csproj
+++ b/OneOf/OneOf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net45;netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Authors>Harry McIntyre</Authors>
     <Title>OneOf - Easy Discriminated Unions for c#</Title>
     <Company>Harry McIntyre</Company>
@@ -23,6 +23,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/OneOf/OneOfBaseT0.generated.cs
+++ b/OneOf/OneOfBaseT0.generated.cs
@@ -1,11 +1,14 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0> : IOneOf
     {
-        readonly T0 _value0;
+        readonly T0? _value0;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0> input)
@@ -18,7 +21,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -31,26 +34,26 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0)
+        public void Switch(Action<T0>? f0)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0)
+        public TResult Match<TResult>(Func<T0, TResult>? f0)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             throw new InvalidOperationException();
         }
@@ -67,7 +70,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfBaseT1.generated.cs
+++ b/OneOf/OneOfBaseT1.generated.cs
@@ -1,12 +1,15 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
+        readonly T0? _value0;
+        readonly T1? _value1;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1> input)
@@ -20,7 +23,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -35,39 +38,39 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1)
+        public void Switch(Action<T0>? f0, Action<T1>? f1)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             throw new InvalidOperationException();
         }
@@ -76,24 +79,24 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out T1 remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out T1 remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
+                1 => _value1!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out T0 remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out T0 remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -109,7 +112,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfBaseT2.generated.cs
+++ b/OneOf/OneOfBaseT2.generated.cs
@@ -1,13 +1,16 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2> input)
@@ -22,7 +25,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -39,52 +42,52 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             throw new InvalidOperationException();
         }
@@ -93,39 +96,39 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
+                1 => _value1!,
+                2 => _value2!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
+                2 => _value2!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -142,7 +145,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfBaseT3.generated.cs
+++ b/OneOf/OneOfBaseT3.generated.cs
@@ -1,14 +1,17 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3> input)
@@ -24,7 +27,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -43,65 +46,65 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             throw new InvalidOperationException();
         }
@@ -110,56 +113,56 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
+                2 => _value2!,
+                3 => _value3!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
+                3 => _value3!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -177,7 +180,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfBaseT4.generated.cs
+++ b/OneOf/OneOfBaseT4.generated.cs
@@ -1,15 +1,18 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4> input)
@@ -26,7 +29,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -47,78 +50,78 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             throw new InvalidOperationException();
         }
@@ -127,75 +130,75 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
+                3 => _value3!,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -214,7 +217,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfBaseT5.generated.cs
+++ b/OneOf/OneOfBaseT5.generated.cs
@@ -1,16 +1,19 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5> input)
@@ -28,7 +31,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -51,91 +54,91 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             throw new InvalidOperationException();
         }
@@ -144,96 +147,96 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -253,7 +256,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfBaseT6.generated.cs
+++ b/OneOf/OneOfBaseT6.generated.cs
@@ -1,17 +1,20 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6> input)
@@ -30,7 +33,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -55,104 +58,104 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             throw new InvalidOperationException();
         }
@@ -161,119 +164,119 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -294,7 +297,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfBaseT7.generated.cs
+++ b/OneOf/OneOfBaseT7.generated.cs
@@ -1,18 +1,21 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> input)
@@ -32,7 +35,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -59,117 +62,117 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             throw new InvalidOperationException();
         }
@@ -178,144 +181,144 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -337,7 +340,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfBaseT8.generated.cs
+++ b/OneOf/OneOfBaseT8.generated.cs
@@ -1,19 +1,22 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
         readonly int _index;
 
         protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> input)
@@ -34,7 +37,7 @@ namespace OneOf
             }
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -63,130 +66,130 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
 
         
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             throw new InvalidOperationException();
         }
@@ -195,171 +198,171 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -382,7 +385,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfT0.generated.cs
+++ b/OneOf/OneOfT0.generated.cs
@@ -1,20 +1,23 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0> : IOneOf
     {
-        readonly T0 _value0;
+        readonly T0? _value0;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default)
+        OneOf(int index, T0? value0 = default)
         {
             _index = index;
             _value0 = value0;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -27,26 +30,26 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
 
         public static implicit operator OneOf<T0>(T0 t) => new OneOf<T0>(0, value0: t);
 
-        public void Switch(Action<T0> f0)
+        public void Switch(Action<T0>? f0)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0)
+        public TResult Match<TResult>(Func<T0, TResult>? f0)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             throw new InvalidOperationException();
         }
@@ -62,7 +65,7 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
+                0 => mapFunc(_value0!),
                 _ => throw new InvalidOperationException()
             };
         }
@@ -75,7 +78,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfT1.generated.cs
+++ b/OneOf/OneOfT1.generated.cs
@@ -1,22 +1,25 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
+        readonly T0? _value0;
+        readonly T1? _value1;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default)
         {
             _index = index;
             _value0 = value0;
             _value1 = value1;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -31,40 +34,40 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1>(T0 t) => new OneOf<T0, T1>(0, value0: t);
         public static implicit operator OneOf<T0, T1>(T1 t) => new OneOf<T0, T1>(1, value1: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1)
+        public void Switch(Action<T0>? f0, Action<T1>? f1)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             throw new InvalidOperationException();
         }
@@ -81,8 +84,8 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -95,30 +98,30 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
+                0 => _value0!,
+                1 => mapFunc(_value1!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out T1 remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out T1 remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
+                1 => _value1!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out T0 remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out T0 remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -134,7 +137,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfT2.generated.cs
+++ b/OneOf/OneOfT2.generated.cs
@@ -1,16 +1,19 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default)
         {
             _index = index;
             _value0 = value0;
@@ -18,7 +21,7 @@ namespace OneOf
             _value2 = value2;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -35,54 +38,54 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2>(T0 t) => new OneOf<T0, T1, T2>(0, value0: t);
         public static implicit operator OneOf<T0, T1, T2>(T1 t) => new OneOf<T0, T1, T2>(1, value1: t);
         public static implicit operator OneOf<T0, T1, T2>(T2 t) => new OneOf<T0, T1, T2>(2, value2: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             throw new InvalidOperationException();
         }
@@ -100,9 +103,9 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -115,9 +118,9 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -130,46 +133,46 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
+                1 => _value1!,
+                2 => _value2!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
+                2 => _value2!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -186,7 +189,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfT3.generated.cs
+++ b/OneOf/OneOfT3.generated.cs
@@ -1,17 +1,20 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default)
         {
             _index = index;
             _value0 = value0;
@@ -20,7 +23,7 @@ namespace OneOf
             _value3 = value3;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -39,19 +42,19 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3>(T0 t) => new OneOf<T0, T1, T2, T3>(0, value0: t);
@@ -59,48 +62,48 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3>(T2 t) => new OneOf<T0, T1, T2, T3>(2, value2: t);
         public static implicit operator OneOf<T0, T1, T2, T3>(T3 t) => new OneOf<T0, T1, T2, T3>(3, value3: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             throw new InvalidOperationException();
         }
@@ -119,10 +122,10 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -135,10 +138,10 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -151,10 +154,10 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -167,64 +170,64 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
+                2 => _value2!,
+                3 => _value3!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
+                3 => _value3!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -242,7 +245,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfT4.generated.cs
+++ b/OneOf/OneOfT4.generated.cs
@@ -1,18 +1,21 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default)
         {
             _index = index;
             _value0 = value0;
@@ -22,7 +25,7 @@ namespace OneOf
             _value4 = value4;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -43,23 +46,23 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4>(T0 t) => new OneOf<T0, T1, T2, T3, T4>(0, value0: t);
@@ -68,57 +71,57 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4>(T3 t) => new OneOf<T0, T1, T2, T3, T4>(3, value3: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4>(T4 t) => new OneOf<T0, T1, T2, T3, T4>(4, value4: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             throw new InvalidOperationException();
         }
@@ -138,11 +141,11 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -155,11 +158,11 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -172,11 +175,11 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -189,11 +192,11 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -206,84 +209,84 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
+                3 => _value3!,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
+                4 => _value4!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -302,7 +305,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfT5.generated.cs
+++ b/OneOf/OneOfT5.generated.cs
@@ -1,19 +1,22 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default)
         {
             _index = index;
             _value0 = value0;
@@ -24,7 +27,7 @@ namespace OneOf
             _value5 = value5;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -47,27 +50,27 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5>(0, value0: t);
@@ -77,66 +80,66 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5>(4, value4: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5>(5, value5: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             throw new InvalidOperationException();
         }
@@ -157,12 +160,12 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -175,12 +178,12 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -193,12 +196,12 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -211,12 +214,12 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -229,12 +232,12 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -247,106 +250,106 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
+                4 => _value4!,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
+                5 => _value5!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -366,7 +369,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfT6.generated.cs
+++ b/OneOf/OneOfT6.generated.cs
@@ -1,20 +1,23 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default)
         {
             _index = index;
             _value0 = value0;
@@ -26,7 +29,7 @@ namespace OneOf
             _value6 = value6;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -51,31 +54,31 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(0, value0: t);
@@ -86,75 +89,75 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(5, value5: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(6, value6: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             throw new InvalidOperationException();
         }
@@ -176,13 +179,13 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -195,13 +198,13 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -214,13 +217,13 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -233,13 +236,13 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -252,13 +255,13 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -271,13 +274,13 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -290,130 +293,130 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
+                5 => _value5!,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
+                6 => _value6!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -434,7 +437,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfT7.generated.cs
+++ b/OneOf/OneOfT7.generated.cs
@@ -1,21 +1,24 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default)
         {
             _index = index;
             _value0 = value0;
@@ -28,7 +31,7 @@ namespace OneOf
             _value7 = value7;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -55,35 +58,35 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(0, value0: t);
@@ -95,84 +98,84 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(6, value6: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(7, value7: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             throw new InvalidOperationException();
         }
@@ -195,14 +198,14 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -215,14 +218,14 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -235,14 +238,14 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -255,14 +258,14 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -275,14 +278,14 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -295,14 +298,14 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -315,14 +318,14 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -335,156 +338,156 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
+                6 => _value6!,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
+                7 => _value7!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -506,7 +509,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/OneOf/OneOfT8.generated.cs
+++ b/OneOf/OneOfT8.generated.cs
@@ -1,22 +1,25 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using static OneOf.Functions;
 
 namespace OneOf
 {
     public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
     {
-        readonly T0 _value0;
-        readonly T1 _value1;
-        readonly T2 _value2;
-        readonly T3 _value3;
-        readonly T4 _value4;
-        readonly T5 _value5;
-        readonly T6 _value6;
-        readonly T7 _value7;
-        readonly T8 _value8;
+        readonly T0? _value0;
+        readonly T1? _value1;
+        readonly T2? _value2;
+        readonly T3? _value3;
+        readonly T4? _value4;
+        readonly T5? _value5;
+        readonly T6? _value6;
+        readonly T7? _value7;
+        readonly T8? _value8;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default)
+        OneOf(int index, T0? value0 = default, T1? value1 = default, T2? value2 = default, T3? value3 = default, T4? value4 = default, T5? value5 = default, T6? value6 = default, T7? value7 = default, T8? value8 = default)
         {
             _index = index;
             _value0 = value0;
@@ -30,7 +33,7 @@ namespace OneOf
             _value8 = value8;
         }
 
-        public object Value =>
+        public object? Value =>
             _index switch
             {
                 0 => _value0,
@@ -59,39 +62,39 @@ namespace OneOf
 
         public T0 AsT0 =>
             _index == 0 ?
-                _value0 :
+                _value0! :
                 throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
         public T1 AsT1 =>
             _index == 1 ?
-                _value1 :
+                _value1! :
                 throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
         public T2 AsT2 =>
             _index == 2 ?
-                _value2 :
+                _value2! :
                 throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
         public T3 AsT3 =>
             _index == 3 ?
-                _value3 :
+                _value3! :
                 throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
         public T4 AsT4 =>
             _index == 4 ?
-                _value4 :
+                _value4! :
                 throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
         public T5 AsT5 =>
             _index == 5 ?
-                _value5 :
+                _value5! :
                 throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
         public T6 AsT6 =>
             _index == 6 ?
-                _value6 :
+                _value6! :
                 throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
         public T7 AsT7 =>
             _index == 7 ?
-                _value7 :
+                _value7! :
                 throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
         public T8 AsT8 =>
             _index == 8 ?
-                _value8 :
+                _value8! :
                 throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(0, value0: t);
@@ -104,93 +107,93 @@ namespace OneOf
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(7, value7: t);
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(8, value8: t);
 
-        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
+        public void Switch(Action<T0>? f0, Action<T1>? f1, Action<T2>? f2, Action<T3>? f3, Action<T4>? f4, Action<T5>? f5, Action<T6>? f6, Action<T7>? f7, Action<T8>? f8)
         {
             if (_index == 0 && f0 != null)
             {
-                f0(_value0);
+                f0(_value0!);
                 return;
             }
             if (_index == 1 && f1 != null)
             {
-                f1(_value1);
+                f1(_value1!);
                 return;
             }
             if (_index == 2 && f2 != null)
             {
-                f2(_value2);
+                f2(_value2!);
                 return;
             }
             if (_index == 3 && f3 != null)
             {
-                f3(_value3);
+                f3(_value3!);
                 return;
             }
             if (_index == 4 && f4 != null)
             {
-                f4(_value4);
+                f4(_value4!);
                 return;
             }
             if (_index == 5 && f5 != null)
             {
-                f5(_value5);
+                f5(_value5!);
                 return;
             }
             if (_index == 6 && f6 != null)
             {
-                f6(_value6);
+                f6(_value6!);
                 return;
             }
             if (_index == 7 && f7 != null)
             {
-                f7(_value7);
+                f7(_value7!);
                 return;
             }
             if (_index == 8 && f8 != null)
             {
-                f8(_value8);
+                f8(_value8!);
                 return;
             }
             throw new InvalidOperationException();
         }
 
-        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
+        public TResult Match<TResult>(Func<T0, TResult>? f0, Func<T1, TResult>? f1, Func<T2, TResult>? f2, Func<T3, TResult>? f3, Func<T4, TResult>? f4, Func<T5, TResult>? f5, Func<T6, TResult>? f6, Func<T7, TResult>? f7, Func<T8, TResult>? f8)
         {
             if (_index == 0 && f0 != null)
             {
-                return f0(_value0);
+                return f0(_value0!);
             }
             if (_index == 1 && f1 != null)
             {
-                return f1(_value1);
+                return f1(_value1!);
             }
             if (_index == 2 && f2 != null)
             {
-                return f2(_value2);
+                return f2(_value2!);
             }
             if (_index == 3 && f3 != null)
             {
-                return f3(_value3);
+                return f3(_value3!);
             }
             if (_index == 4 && f4 != null)
             {
-                return f4(_value4);
+                return f4(_value4!);
             }
             if (_index == 5 && f5 != null)
             {
-                return f5(_value5);
+                return f5(_value5!);
             }
             if (_index == 6 && f6 != null)
             {
-                return f6(_value6);
+                return f6(_value6!);
             }
             if (_index == 7 && f7 != null)
             {
-                return f7(_value7);
+                return f7(_value7!);
             }
             if (_index == 8 && f8 != null)
             {
-                return f8(_value8);
+                return f8(_value8!);
             }
             throw new InvalidOperationException();
         }
@@ -214,15 +217,15 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => mapFunc(_value0!),
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -235,15 +238,15 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => mapFunc(_value1!),
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -256,15 +259,15 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => mapFunc(_value2!),
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -277,15 +280,15 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => mapFunc(_value3!),
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -298,15 +301,15 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => mapFunc(_value4!),
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -319,15 +322,15 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => mapFunc(_value5!),
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -340,15 +343,15 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => mapFunc(_value6!),
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -361,15 +364,15 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => mapFunc(_value7!),
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
         }
@@ -382,184 +385,184 @@ namespace OneOf
             }
             return _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => mapFunc(_value8!),
                 _ => throw new InvalidOperationException()
             };
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8> remainder)
+		public bool TryPickT0([MaybeNullWhen(false)] out T0 value, [MaybeNullWhen(true)] out OneOf<T1, T2, T3, T4, T5, T6, T7, T8> remainder)
 		{
 			value = IsT0 ? AsT0 : default;
             remainder = _index switch
             {
                 0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT0;
 		}
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8> remainder)
+		public bool TryPickT1([MaybeNullWhen(false)] out T1 value, [MaybeNullWhen(true)] out OneOf<T0, T2, T3, T4, T5, T6, T7, T8> remainder)
 		{
 			value = IsT1 ? AsT1 : default;
             remainder = _index switch
             {
-                0 => AsT0,
+                0 => _value0!,
                 1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT1;
 		}
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8> remainder)
+		public bool TryPickT2([MaybeNullWhen(false)] out T2 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T3, T4, T5, T6, T7, T8> remainder)
 		{
 			value = IsT2 ? AsT2 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
+                0 => _value0!,
+                1 => _value1!,
                 2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT2;
 		}
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8> remainder)
+		public bool TryPickT3([MaybeNullWhen(false)] out T3 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T4, T5, T6, T7, T8> remainder)
 		{
 			value = IsT3 ? AsT3 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
                 3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT3;
 		}
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8> remainder)
+		public bool TryPickT4([MaybeNullWhen(false)] out T4 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T5, T6, T7, T8> remainder)
 		{
 			value = IsT4 ? AsT4 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
                 4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT4;
 		}
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8> remainder)
+		public bool TryPickT5([MaybeNullWhen(false)] out T5 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T6, T7, T8> remainder)
 		{
 			value = IsT5 ? AsT5 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
                 5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
+                6 => _value6!,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT5;
 		}
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8> remainder)
+		public bool TryPickT6([MaybeNullWhen(false)] out T6 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T7, T8> remainder)
 		{
 			value = IsT6 ? AsT6 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
                 6 => default,
-                7 => AsT7,
-                8 => AsT8,
+                7 => _value7!,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT6;
 		}
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8> remainder)
+		public bool TryPickT7([MaybeNullWhen(false)] out T7 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T8> remainder)
 		{
 			value = IsT7 ? AsT7 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
                 7 => default,
-                8 => AsT8,
+                8 => _value8!,
                 _ => throw new InvalidOperationException()
             };
 			return this.IsT7;
 		}
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7> remainder)
+		public bool TryPickT8([MaybeNullWhen(false)] out T8 value, [MaybeNullWhen(true)] out OneOf<T0, T1, T2, T3, T4, T5, T6, T7> remainder)
 		{
 			value = IsT8 ? AsT8 : default;
             remainder = _index switch
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
+                0 => _value0!,
+                1 => _value1!,
+                2 => _value2!,
+                3 => _value3!,
+                4 => _value4!,
+                5 => _value5!,
+                6 => _value6!,
+                7 => _value7!,
                 8 => default,
                 _ => throw new InvalidOperationException()
             };
@@ -582,7 +585,7 @@ namespace OneOf
                 _ => false
             };
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {


### PR DESCRIPTION
This addresses #198 and probably includes the intended changes by #199 and #190.

I tried to only include the minimal changes to support Nullable Reference Type-annotations, which are available since .NET Core 2.1/.NET Standard 2.1, but ended up updating dependencies and synchronising the targets of `OneOf` and `OneOf.Extended` to get rid of build-time warning of known security vulnerabilities. I updated the target-framework from .NET 6 to .NET 9 for the same reason. .NET 9 seems to be the most recent version your appveyor-pipeline supports; I would have preferred .NET 10 as latest LTS-version